### PR TITLE
#30: Fix double alert when restoring Mudrunner savegame

### DIFF
--- a/templates/base.hbs
+++ b/templates/base.hbs
@@ -487,8 +487,6 @@
                     }
                     load_subpage('/mud-runner', show_buttons, show_buttons);
                     load_saves_mudrunner();
-                } else {
-                    alert(http.responseText);
                 }
             }
         }


### PR DESCRIPTION
The deleted else clause was completely pointless.

Signed-off-by: Thomas Vauti-Rienößl <43434564+ThomCoder@users.noreply.github.com>